### PR TITLE
Use replaceAll in formatChar

### DIFF
--- a/quiz/js/main.js
+++ b/quiz/js/main.js
@@ -197,33 +197,24 @@ function judge() {
 
 function formatChar(str){
   //Delete 全角半角空白、「-」、「'」、「 -ZZ ver.-」、「、」、「・」「「」」、「.」、「…」、「☆」、「:」、「!?！？」
-  var delTarget = [' -ZZ ver.-',' ','　','-','\'',',','.','、','。','･','・','「','」','…','☆',':','：','!','?','！','？','"','[',']','〜','ー'];
-  for (const element of delTarget) {
-    if(str == null || str == ''){
-      break;
-    }
-    if (str.indexOf(element) != -1) {
-      //strにelementを含む場合の処理
-      str = str.split(element).join('');
-    }
+  var delTargets = [' -ZZ ver.-',' ','　','-','\'',',','.','、','。','･','・','「','」','…','☆',':','：','!','?','！','？','"','[',']','〜','ー'];
+  for (const delTarget of delTargets) {
+    str = str.replaceAll(delTarget, '');
   }
 
-  if(str != null || str != ''){
-    //Replace　ひらがな→カタカナ、全角→半角（ローマ字）、大文字→小文字、φ→O
-
-    str = str.replace(/[ぁ-ん]/g, function(s) {
+  //Replace　ひらがな→カタカナ、全角→半角（ローマ字）、大文字→小文字、φ→O
+  str = str.replace(/[ぁ-ん]/g, function(s) {
       return String.fromCharCode(s.charCodeAt(0) + 0x60);
-    });
+  });
 
-    str = str.replace(/[Ａ-Ｚａ-ｚ０-９]/g, function(s) {
+  str = str.replace(/[Ａ-Ｚａ-ｚ０-９]/g, function(s) {
       return String.fromCharCode(s.charCodeAt(0) - 0xFEE0);
-    });
+  });
 
-    str = str.toLowerCase();
+  str = str.toLowerCase();
 
-    str = str.split('φ').join('O');
-  }
-  
+  str = str.replaceAll('φ', 'O');
+
   return str;
 }
 

--- a/quiz/js/main.js
+++ b/quiz/js/main.js
@@ -204,11 +204,11 @@ function formatChar(str){
 
   //Replace　ひらがな→カタカナ、全角→半角（ローマ字）、大文字→小文字、φ→O
   str = str.replace(/[ぁ-ん]/g, function(s) {
-      return String.fromCharCode(s.charCodeAt(0) + 0x60);
+    return String.fromCharCode(s.charCodeAt(0) + 0x60);
   });
 
   str = str.replace(/[Ａ-Ｚａ-ｚ０-９]/g, function(s) {
-      return String.fromCharCode(s.charCodeAt(0) - 0xFEE0);
+    return String.fromCharCode(s.charCodeAt(0) - 0xFEE0);
   });
 
   str = str.toLowerCase();


### PR DESCRIPTION
This change is for refactoring purposes and does not affect the behavior.

https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll
`replaceAll` can replace certain patterns or substrings in a string at once.
This can be used to delete.

`if(str != null || str != '')` probably intends `if(str != null && str != '')` , but this if statement seems unnecessary for the following reasons.
* `str` can be an empty string by `replace` or `replaceAll`, but it can never be null.
* Nothing happens when `replace` or `replaceAll` is done on an empty string.
* Only strings are passed as the `formatChar` argument.